### PR TITLE
Ignore some audit warnings

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,5 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0436", # unmaintained paste
+    "RUSTSEC-2024-0370", # unmaintained proc-macro-error
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,7 +6,7 @@ on:
   push:
     paths:
       - ".github/workflows/audit.yml"
-      - "audit.toml"
+      - ".cargo/audit.toml"
       - "**/Cargo.toml"
       - "**/Cargo.lock"
 


### PR DESCRIPTION
These are about unmaintained crates used by other deps. I don't care.